### PR TITLE
feat: implement graceful shutdown and refactor command registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.vscode/
+.idea/
+.DS_Store
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.tmp
+*.out
+*.json
+*.log
+.env
+vendor/
+bin/
+build/

--- a/src/cmd/fix.go
+++ b/src/cmd/fix.go
@@ -1,73 +1,75 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
-	"github.com/spf13/cobra"
 )
 
 var selectedFiles = make(map[string]bool)
 
-var fixCmd = &cobra.Command{
-	Use:   "fix",
-	Short: "Detect and fix issues in a project",
-	Long:  `An interactive tool to scan project files, identify potential problems, and suggest fixes.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		path := "."
-		if len(args) > 0 {
-			path = args[0]
-		}
-
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			fmt.Println("Error: The specified path does not exist.")
-			return
-		}
-
-		app := tview.NewApplication()
-		treeRoot := tview.NewTreeNode(path).SetSelectable(false)
-		treeView := tview.NewTreeView().SetRoot(treeRoot).SetCurrentNode(treeRoot)
-
-		loadFilesIntoTree(treeRoot, path)
-
-		treeView.SetSelectedFunc(func(node *tview.TreeNode) {
-			path, ok := node.GetReference().(string)
-			if !ok {
-				return
+func newFixCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fix",
+		Short: "Detect and fix issues in a project",
+		Long:  `An interactive tool to scan project files, identify potential problems, and suggest fixes.`,
+		RunE: func(_ *cobra.Command, args []string) error {
+			path := "."
+			if len(args) > 0 {
+				path = args[0]
 			}
 
-			if selectedFiles[path] {
-				deselectRecursively(node)
-			} else {
-				selectRecursively(node)
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				return errors.New("the specified path does not exist")
 			}
-		})
 
-		treeView.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-			if event.Key() == tcell.KeyEnter {
-				app.Stop()
-				printSelectedFiles()
-				return nil
+			app := tview.NewApplication()
+			treeRoot := tview.NewTreeNode(path).SetSelectable(false)
+			treeView := tview.NewTreeView().SetRoot(treeRoot).SetCurrentNode(treeRoot)
+
+			loadFilesIntoTree(treeRoot, path)
+
+			treeView.SetSelectedFunc(func(node *tview.TreeNode) {
+				path, ok := node.GetReference().(string)
+				if !ok {
+					return
+				}
+
+				if selectedFiles[path] {
+					deselectRecursively(node)
+				} else {
+					selectRecursively(node)
+				}
+			})
+
+			treeView.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+				if event.Key() == tcell.KeyEnter {
+					app.Stop()
+					printSelectedFiles()
+					return nil
+				}
+				return event
+			})
+
+			layout := tview.NewFlex().
+				SetDirection(tview.FlexRow).
+				AddItem(tview.NewTextView().SetText("Use ↑↓ to navigate, Space to select, Enter to confirm."), 1, 1, false).
+				AddItem(treeView, 0, 1, true)
+
+			if err := app.SetRoot(layout, true).Run(); err != nil {
+				return err
 			}
-			return event
-		})
 
-		layout := tview.NewFlex().
-			SetDirection(tview.FlexRow).
-			AddItem(tview.NewTextView().SetText("Use ↑↓ to navigate, Space to select, Enter to confirm."), 1, 1, false).
-			AddItem(treeView, 0, 1, true)
+			return nil
+		},
+	}
 
-		if err := app.SetRoot(layout, true).Run(); err != nil {
-			panic(err)
-		}
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(fixCmd)
+	return cmd
 }
 
 func loadFilesIntoTree(parentNode *tview.TreeNode, path string) {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -1,25 +1,19 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "trood",
-	Short: "A CLI tool for detecting and fixing issues in your projects.",
-	Long: `Trood is an interactive command-line tool designed to scan project files,
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trood",
+		Short: "A CLI tool for detecting and fixing issues in your projects.",
+		Long: `Trood is an interactive command-line tool designed to scan project files,
 identify potential issues, and provide actionable fixes.`,
-}
-
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	}
-}
 
-func init() {
-	rootCmd.CompletionOptions.DisableDefaultCmd = true
+	cmd.AddCommand(newFixCmd())
+
+	return cmd
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,7 +1,20 @@
 package main
 
-import "github.com/troodinc/trood/cmd"
+import (
+	"context"
+	"github.com/troodinc/trood/cmd"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+)
 
 func main() {
-	cmd.Execute()
+	ctx, shutdown := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer shutdown()
+
+	root := cmd.NewRootCmd()
+	if err := root.ExecuteContext(ctx); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
- Added graceful shutdown in main using signal.NotifyContext for proper termination.
- Passed context to the root command through ExecuteContext.
- Moved subcommand registration into the public root command, replacing init-based setup for improved readability and maintainability.