### PR TITLE
Add running instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ Trood CLI solves two main problems:
 2. **Scaling under pressure**. Deadlines are tight, and it’s hard to bring in new people fast. Trood CLI helps by finding known issues and summarizing the results, saving you time and reducing the cost of delays.
 
 ---
+## Running
+
+This assumes you have cloned this repo to the current directory and have Go installed.
+
+```sh
+cd src
+
+go build
+
+./trood
+```
+
+Then you can follow the `trood` command's CLI help for usage instructions.
+
+---
 
 ## What We Offer
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,28 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# built binary
+trood


### PR DESCRIPTION
* Make it clear how to run it and that Go must be installed.
* Add a standard .gitignore file